### PR TITLE
Added the ability to specify install location

### DIFF
--- a/static-get
+++ b/static-get
@@ -16,7 +16,7 @@ _usage() {
     printf "%b\\n" "  -s, --search [pattern]      search packages by pattern"
     printf "%b\\n" "  -x, --extract               extract after download"
     printf "%b\\n" "  -i, --install               install after download"
-    printf "%b\\n" "  -p, --prefix [dir]          installs the package to a specific location"
+    printf "%b\\n" "  -p, --prefix [dir]          specifies an install location for the package"
     printf "%b\\n" "  -n, --dry-run               perform a trial run with no changes made"
     printf "%b\\n" "  -c, --clean-cache           remove temporal files"
     printf "\\n"
@@ -432,7 +432,6 @@ for arg in "${@}"; do #parse options
         -i|--install) install="1"; shift ;;
         -n|--dry-run) dry_run="1"; shift ;;
         '-p'|'--prefix'|-p*|--prefix*)
-            install="1"
             case "${arg}" in
                 '-p'|'--prefix')
                     if [ "${#}" -gt "1" ]; then

--- a/static-get
+++ b/static-get
@@ -5,7 +5,7 @@
 #example: static-get git
 #git-1.8.2.1-3.tar.gz:sha512sum
 
-VERSION="2019.09.03-15:08"
+VERSION="2019.09.10-22:55"
 
 _usage() {
     printf "%b\\n" "Usage: ${progname} [OPTION]... PACKAGE ..."

--- a/static-get
+++ b/static-get
@@ -5,7 +5,7 @@
 #example: static-get git
 #git-1.8.2.1-3.tar.gz:sha512sum
 
-VERSION="2017.07.04-12:19"
+VERSION="2019.09.03-15:08"
 
 _usage() {
     printf "%b\\n" "Usage: ${progname} [OPTION]... PACKAGE ..."
@@ -15,6 +15,7 @@ _usage() {
     printf "%b\\n" "  -o, --output [file]         write to file"
     printf "%b\\n" "  -s, --search [pattern]      search packages by pattern"
     printf "%b\\n" "  -x, --extract               extract after download"
+    printf "%b\\n" "  -i, --install               install after download"
     printf "%b\\n" "  -n, --dry-run               perform a trial run with no changes made"
     printf "%b\\n" "  -c, --clean-cache           remove temporal files"
     printf "\\n"
@@ -369,7 +370,26 @@ _static_get() {
                 if [ "${_sget__hash}" = "${_sget__hash_new}" ]; then
                     _cat "${tmpcache}.${uniq_id_mirror}/${_sget__bfile}"
 
-                    if [ "${extract}" ]; then
+                    if [ "${install}" ]; then
+                        _mkdir_p "${directory}/${_sget__bfile%%.tar*}"
+                        (cd "${directory}/${_sget__bfile%%.tar*}" && \
+                        ${compress_bin} < "../${_sget__bfile}"  | tar xf -) && \
+                        if [ -w "/" ]; then
+                            cd "${_sget__bfile%%.tar*}" && \
+                            cp -r * "/" || return 1
+                        elif [ command -v "sudo" >/dev/null 2>&1 ]; then
+                            cd "${_sget__bfile%%.tar*}" && \
+                            sudo cp -r * "/" || return 1
+                        else
+                            printf "%s\\n" "ERROR: sudo isn't available, exiting ..." >&2
+                        fi
+                        
+                        if ! [ "${extract}" ]; then
+                            cd "../" && rm -rf "${_sget__bfile%%.tar*}"
+                        else
+                            printf "%s\\n" "${_sget__bfile%%.tar*}/" | sed 's:\./::'
+                        fi
+                    elif [ "${extract}" ]; then
                         _mkdir_p "${directory}/${_sget__bfile%%.tar*}"
                         (cd "${directory}/${_sget__bfile%%.tar*}" && \
                         ${compress_bin} < "../${_sget__bfile}"  | tar xf -) && \
@@ -407,6 +427,7 @@ for arg in "${@}"; do #parse options
         -q|--quiet)   quiet="1";   shift ;;
         -v|--verbose) verbose="1"; shift ;;
         -x|--extract) extract="1"; shift ;;
+        -i|--install) install="1"; shift ;;
         -n|--dry-run) dry_run="1"; shift ;;
         '-d'|'--download'|-d*|--download*)
             case "${arg}" in

--- a/static-get
+++ b/static-get
@@ -16,6 +16,7 @@ _usage() {
     printf "%b\\n" "  -s, --search [pattern]      search packages by pattern"
     printf "%b\\n" "  -x, --extract               extract after download"
     printf "%b\\n" "  -i, --install               install after download"
+    printf "%b\\n" "  -p, --prefix [dir]          installs the package to a specific location"
     printf "%b\\n" "  -n, --dry-run               perform a trial run with no changes made"
     printf "%b\\n" "  -c, --clean-cache           remove temporal files"
     printf "\\n"
@@ -380,12 +381,12 @@ _static_get() {
 
                     if [ "${install}" ]; then
                         _extract "${extract}"
-                        if [ -w "/" ]; then
+                        if [ -w "${prefix}/" ]; then
                             cd "${_sget__bfile%%.tar*}" && \
-                            cp -r * "/" || return 1
+                            cp -r * "${prefix}/" || return 1
                         elif [ command -v "sudo" >/dev/null 2>&1 ]; then
                             cd "${_sget__bfile%%.tar*}" && \
-                            sudo cp -r * "/" || return 1
+                            sudo cp -r * "${prefix}/" || return 1
                         else
                             printf "%s\\n" "ERROR: sudo isn't available, exiting ..." >&2
                         fi
@@ -430,6 +431,27 @@ for arg in "${@}"; do #parse options
         -x|--extract) extract="1"; shift ;;
         -i|--install) install="1"; shift ;;
         -n|--dry-run) dry_run="1"; shift ;;
+        '-p'|'--prefix'|-p*|--prefix*)
+            install="1"
+            case "${arg}" in
+                '-p'|'--prefix')
+                    if [ "${#}" -gt "1" ]; then
+                        case "${2}" in
+                            '-') : ;; #special stdout character
+                             -*) printf "Option '${arg}' requires a parameter ${2}" ;;
+                            '.') prefix="${PWD}" ; break ;;
+                            '..') prefix="${PWD}/../" ; break ;;
+                        esac
+                        shift; prefix="${1}"; [ "${1}" ] && shift
+                    else
+                        prefix="${PWD}"
+                    fi
+                    ;;
+                -p*) prefix="${1#-p}"; shift ;;
+                --prefix*) prefix="${1#--prefix}"; shift ;;
+            esac
+            ;;
+
         '-d'|'--download'|-d*|--download*)
             case "${arg}" in
                 '-d'|'--download')

--- a/static-get
+++ b/static-get
@@ -334,6 +334,14 @@ _static_search() {
     fi
 }
 
+_extract() {
+    _mkdir_p "${directory}/${_sget__bfile%%.tar*}"
+    (cd "${directory}/${_sget__bfile%%.tar*}" && \
+    ${compress_bin} < "../${_sget__bfile}"  | tar xf -)
+
+    [ "${1}" ] && printf "%s\\n" "${directory}/${_sget__bfile%%.tar*}/" | sed 's:\./::'
+}
+
 _static_get() {
     [ -z "${1}" ] && return 1 || _set_defaults
     for package in "${@}"; do
@@ -371,9 +379,7 @@ _static_get() {
                     _cat "${tmpcache}.${uniq_id_mirror}/${_sget__bfile}"
 
                     if [ "${install}" ]; then
-                        _mkdir_p "${directory}/${_sget__bfile%%.tar*}"
-                        (cd "${directory}/${_sget__bfile%%.tar*}" && \
-                        ${compress_bin} < "../${_sget__bfile}"  | tar xf -) && \
+                        _extract "${extract}"
                         if [ -w "/" ]; then
                             cd "${_sget__bfile%%.tar*}" && \
                             cp -r * "/" || return 1
@@ -386,14 +392,9 @@ _static_get() {
                         
                         if ! [ "${extract}" ]; then
                             cd "../" && rm -rf "${_sget__bfile%%.tar*}"
-                        else
-                            printf "%s\\n" "${_sget__bfile%%.tar*}/" | sed 's:\./::'
                         fi
                     elif [ "${extract}" ]; then
-                        _mkdir_p "${directory}/${_sget__bfile%%.tar*}"
-                        (cd "${directory}/${_sget__bfile%%.tar*}" && \
-                        ${compress_bin} < "../${_sget__bfile}"  | tar xf -) && \
-                        printf "%s\\n" "${directory}/${_sget__bfile%%.tar*}/" | sed 's:\./::'
+                        _extract "${extract}"
                     fi
                     break
                 else

--- a/tests/tests.db
+++ b/tests/tests.db
@@ -66,10 +66,13 @@ test ! -f /sbin/allcaps
 test -f allcaps-1-1.tar.gz && rm -rf allcaps*
 
 test "$(static-get -fgz -p . allcaps-1-1 2>&1|wc -l)" -eq "2"
+test ! -d doc/ && test ! -d sbin/
+
+test "$(static-get -fgz -i -p . allcaps-1-1 2>&1|wc -l)" -eq "2"
 test -d doc/ && test -d sbin/
 rm -rf doc/ test/
 
-test "$(static-get -fgz -p .. allcaps-1-1 2>&1|wc -l)" -eq "2"
+test "$(static-get -fgz -i -p .. allcaps-1-1 2>&1|wc -l)" -eq "2"
 test -d ../doc/ && test -d ../sbin/
 rm -rf ../doc/ ../test/
 

--- a/tests/tests.db
+++ b/tests/tests.db
@@ -3,6 +3,7 @@ static-get -h ; test X"${?}"                = X"0"
 printf "%s" '-h' | static-get; test X"${?}" = X"0"
 static-get -d ;   test X"${?}"              = X"1"
 static-get -x ;   test X"${?}"              = X"1"
+static-get -i ;   test X"${?}"              = X"1"
 static-get -n ;   test X"${?}"              = X"1"
 static-get -m ;   test X"${?}"              = X"1"
 static-get -a ;   test X"${?}"              = X"1"
@@ -16,6 +17,7 @@ test X"$(static-get --cui 2>&1|head -1)"               = X"static-get: unrecogni
 test X"$(static-get --download 2>&1|head -1)"          = X"Option '--download' requires a parameter"
 test X"$(static-get --download . 2>&1|head -1)"        = X"static-get: missing arguments"
 test X"$(static-get -x 2>&1|head -1)"                  = X"static-get: missing arguments"
+test X"$(static-get -i 2>&1|head -1)"                  = X"static-get: missing arguments"
 test X"$(static-get --dry-run 2>&1|head -1)"           = X"static-get: missing arguments"
 test X"$(static-get -m 2>&1|head -1)"                  = X"Option '-m' requires a parameter"
 test X"$(static-get --mirror s.minos.io 2>&1|head -1)" = X"static-get: missing arguments"
@@ -58,6 +60,10 @@ test -d allcaps-1-1/ && test -f allcaps-1-1.tar.gz && rm -rf allcaps*
 test "$(static-get -d test -fgz -x allcaps-1-1 2>&1|wc -l)" -eq "2"
 test -d test/ && test -f test/allcaps-1-1.tar.gz && test -d test/allcaps-1-1/
 test ! -f allcaps-1-1.tar.gz && rm -rf test
+
+test "$(static-get -fgz -i allcaps-1-1 2>&1|wc -l)" -eq "2"
+test ! -f /sbin/allcaps
+test -f allcaps-1-1.tar.gz && rm -rf allcaps*
 
 test X"$(static-get -fxz allcaps-1-1 2>&1)" = X"allcaps-1-1.tar.xz"
 test -f allcaps-1-1.tar.xz && rm -rf allcaps-1-1.tar.xz

--- a/tests/tests.db
+++ b/tests/tests.db
@@ -65,6 +65,14 @@ test "$(static-get -fgz -i allcaps-1-1 2>&1|wc -l)" -eq "2"
 test ! -f /sbin/allcaps
 test -f allcaps-1-1.tar.gz && rm -rf allcaps*
 
+test "$(static-get -fgz -p . allcaps-1-1 2>&1|wc -l)" -eq "2"
+test -d doc/ && test -d sbin/
+rm -rf doc/ test/
+
+test "$(static-get -fgz -p .. allcaps-1-1 2>&1|wc -l)" -eq "2"
+test -d ../doc/ && test -d ../sbin/
+rm -rf ../doc/ ../test/
+
 test X"$(static-get -fxz allcaps-1-1 2>&1)" = X"allcaps-1-1.tar.xz"
 test -f allcaps-1-1.tar.xz && rm -rf allcaps-1-1.tar.xz
 

--- a/tests/tests.db
+++ b/tests/tests.db
@@ -70,11 +70,11 @@ test ! -d doc/ && test ! -d sbin/
 
 test "$(static-get -fgz -i -p . allcaps-1-1 2>&1|wc -l)" -eq "2"
 test -d doc/ && test -d sbin/
-rm -rf doc/ test/
+rm -rf doc/ sbin/
 
 test "$(static-get -fgz -i -p .. allcaps-1-1 2>&1|wc -l)" -eq "2"
 test -d ../doc/ && test -d ../sbin/
-rm -rf ../doc/ ../test/
+rm -rf ../doc/ ../sbin/
 
 test X"$(static-get -fxz allcaps-1-1 2>&1)" = X"allcaps-1-1.tar.xz"
 test -f allcaps-1-1.tar.xz && rm -rf allcaps-1-1.tar.xz


### PR DESCRIPTION
An install location can now be specified using `static-get -p <location> <package>`. The previous install system, `static-get -i <package>` effectively works out to `static-get -p / <package>`, but users can now change this if they so wish.

This pull request addresses @maximbaz's comment in #14:
> Nice feature! It would have been nice if we could configure a prefix, i.e. instead of installing to `/bin/` to be able to install to `/opt/bin/`