### PR TITLE
remove url-breaking newline

### DIFF
--- a/deploy/vars.yaml
+++ b/deploy/vars.yaml
@@ -2,5 +2,4 @@ domain:    s.minos.io
 port:      80
 wwwroot:   /var/www/s.minos.io/
 buildroot: /home/admin/minos-static
-cdn:       http://rawgit.loltek.net/https://raw.githubusercontent.com/minos-org/minos-static/79325ed314f92ff71bf27bd80f20983d8b07b6
-29/static-get
+cdn:       http://rawgit.loltek.net/https://raw.githubusercontent.com/minos-org/minos-static/79325ed314f92ff71bf27bd80f20983d8b07b629/static-get


### PR DESCRIPTION
seemingly by accident, commit d46ee9e8e32ece5ddde039d48a5100a8fb9d0128 has a newline in the url.. which broke it.