### PR TITLE
Max peal patch 1 for mktemp

### DIFF
--- a/bifrost-autobuild
+++ b/bifrost-autobuild
@@ -4,6 +4,8 @@
 bdir="$(cd "$(dirname "${0}")" && pwd)"
 alert_mails="m#%#javier.io"
 PS4="> "
+_tempfile-cmd=$(command -v tempfile || command -v mktemp)
+
 
 #crontab jobs run in a very sparse environment
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/bin:/sbin"
@@ -69,7 +71,7 @@ _die() {
 _clone() {
     [ -z "${1}" ] && return 1
     [ -z "${2}" ] && _clone__target="${bdir}/$(_basename "${1}")" || _clone__target="${2}"
-    _clone__stdout="$(tempfile || mktemp)"
+    _clone__stdout="$(_tempfile-cmd)"
 
     printf "%s\\n" "cloning: ${1}"
     if [ -d "${_clone__target}" ]; then

--- a/bifrost-autobuild
+++ b/bifrost-autobuild
@@ -4,7 +4,7 @@
 bdir="$(cd "$(dirname "${0}")" && pwd)"
 alert_mails="m#%#javier.io"
 PS4="> "
-_tempfile-cmd=$(command -v tempfile || command -v mktemp)
+tempfileCMD="$(command -v tempfile || command -v mktemp)"
 
 
 #crontab jobs run in a very sparse environment
@@ -71,7 +71,7 @@ _die() {
 _clone() {
     [ -z "${1}" ] && return 1
     [ -z "${2}" ] && _clone__target="${bdir}/$(_basename "${1}")" || _clone__target="${2}"
-    _clone__stdout="$(_tempfile-cmd)"
+    _clone__stdout="$(tempfileCMD)"
 
     printf "%s\\n" "cloning: ${1}"
     if [ -d "${_clone__target}" ]; then

--- a/bifrost-autobuild
+++ b/bifrost-autobuild
@@ -71,7 +71,7 @@ _die() {
 _clone() {
     [ -z "${1}" ] && return 1
     [ -z "${2}" ] && _clone__target="${bdir}/$(_basename "${1}")" || _clone__target="${2}"
-    _clone__stdout="$(tempfileCMD)"
+    _clone__stdout="$(${tempfileCMD})"
 
     printf "%s\\n" "cloning: ${1}"
     if [ -d "${_clone__target}" ]; then

--- a/bifrost-autobuild
+++ b/bifrost-autobuild
@@ -69,7 +69,7 @@ _die() {
 _clone() {
     [ -z "${1}" ] && return 1
     [ -z "${2}" ] && _clone__target="${bdir}/$(_basename "${1}")" || _clone__target="${2}"
-    _clone__stdout="$(tempfile)"
+    _clone__stdout="$(tempfile || mktemp)"
 
     printf "%s\\n" "cloning: ${1}"
     if [ -d "${_clone__target}" ]; then


### PR DESCRIPTION
on centos 8 exist only mktemp

The following is from man tempfile on a Debian:
BUGS
Exclusive creation is not guaranteed when creating files on NFS partitions. tempfile cannot make temporary directories. **tempfile is deprecated; you should use mktemp(1) instead.**