### PR TITLE
Fix breakage when used with the curl

### DIFF
--- a/static-get
+++ b/static-get
@@ -177,7 +177,7 @@ _fetch() {
            case "${retriever_bin}" in
                wget*) $retriever_bin -O "${2}" "${1}" >/dev/null || \
                       $retriever_bin -O "${2}" "http://${1}" >/dev/null ;;
-               curl*) ${retriever_bin# -O} -o "${2}" "${1}"  >/dev/null ;;
+               curl*) ${retriever_bin% -O} -o "${2}" "${1}"  >/dev/null ;;
                *) return 1 ;;
            esac
            ;;


### PR DESCRIPTION
Fixes issue described in #29 that  occurs when only curl and not wget is installed.