### PR TITLE
tar command compatibility

### DIFF
--- a/static-get
+++ b/static-get
@@ -177,7 +177,7 @@ _fetch() {
            case "${retriever_bin}" in
                wget*) $retriever_bin -O "${2}" "${1}" >/dev/null || \
                       $retriever_bin -O "${2}" "http://${1}" >/dev/null ;;
-               curl*) ${retriever_bin# -O} -o "${2}" "${1}"  >/dev/null ;;
+               curl*) ${retriever_bin% -O} -o "${2}" "${1}"  >/dev/null ;;
                *) return 1 ;;
            esac
            ;;

--- a/static-get
+++ b/static-get
@@ -228,7 +228,7 @@ _get_package_indexes() {
                 (
                 cd "${tmpcache}.${uniq_id_mirror}/${gdistro}/${garch}" || return
                 if   _fetch "${1}/${gdistro}/${garch}/${checksum}sum.tar.${compress_format}"; then
-                    ${compress_bin} < "${checksum}sum.tar.${compress_format}" | tar xf -
+                    ${compress_bin} < "${checksum}sum.tar.${compress_format}" | tar -xf -
                 elif _fetch "${1}/${gdistro}/${garch}/${checksum}sum.txt"; then
                     :
                 else
@@ -353,7 +353,7 @@ _static_search() {
 _extract() {
     _mkdir_p "${directory}/${_sget__bfile%%.tar*}"
     (cd "${directory}/${_sget__bfile%%.tar*}" && \
-    ${compress_bin} < "../${_sget__bfile}"  | tar xf -)
+    ${compress_bin} < "../${_sget__bfile}"  | tar -xf -)
 
     [ "${1}" ] && printf "%s\\n" "${directory}/${_sget__bfile%%.tar*}/" | sed 's:\./::'
 }


### PR DESCRIPTION
In `tar xf file`, `xf` are actually options (`tar -x -f`) and not all `tar` versions support this syntax.

`tar -xf file` is simpler and more portable.